### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -3,6 +3,9 @@
 
 name: Tests
 
+permissions:
+  contents: read
+
 on: push
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/mwalkowski/flask-rsa/security/code-scanning/4](https://github.com/mwalkowski/flask-rsa/security/code-scanning/4)

In general, the fix is to explicitly set `permissions` for the workflow or for individual jobs so that the `GITHUB_TOKEN` has only the scopes required. For this workflow, all steps are local (checkout, setup, install, run tools) and do not need to write back to GitHub, so restricting to `contents: read` at the workflow or job level is sufficient.

The best minimal fix without changing functionality is to add a top‑level `permissions` block right under the `name:` (or `on:`) key in `.github/workflows/python-package.yml`, setting `contents: read`. This applies to all jobs (currently only `build`) and ensures the token cannot be used to push commits, modify releases, etc. No new imports, methods, or other definitions are needed because this is purely a YAML configuration change. Concretely, insert:

```yaml
permissions:
  contents: read
```

after line 5 (or before `jobs:`), preserving indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
